### PR TITLE
Feat/exception-simulation: support offline simulation on the server side

### DIFF
--- a/3.0/adaptivesvc-triple/client/main.go
+++ b/3.0/adaptivesvc-triple/client/main.go
@@ -12,12 +12,12 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/logger"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	_ "dubbo.apache.org/dubbo-go/v3/imports"
-
 	testerpkg "github.com/dubbogo/tools/pkg/tester"
 )
 
 import (
 	"github.com/dubbogo/dubbo-go-benchmark/3.0/adaptivesvc-triple/api"
+	"github.com/dubbogo/dubbo-go-benchmark/3.0/filters/offline_simulator"
 )
 
 const (
@@ -72,6 +72,8 @@ func main() {
 					logger.Infof("Reach Limitation")
 				} else if err.Error() == context.DeadlineExceeded.Error() {
 					logger.Warnf("Consumer Request Timeout, err: %v", err)
+				} else if offline_simulator.IsServerOffline(err) {
+					logger.Warnf("Server offline, err: %v", err)
 				} else {
 					panic(err)
 				}

--- a/3.0/adaptivesvc-triple/client/main.go
+++ b/3.0/adaptivesvc-triple/client/main.go
@@ -72,7 +72,7 @@ func main() {
 					logger.Infof("Reach Limitation")
 				} else if err.Error() == context.DeadlineExceeded.Error() {
 					logger.Warnf("Consumer Request Timeout, err: %v", err)
-				} else if offline_simulator.IsServerOffline(err) {
+				} else if offline_simulator.IsServerOfflineErr(err) {
 					logger.Warnf("Server offline, err: %v", err)
 				} else {
 					panic(err)

--- a/3.0/adaptivesvc-triple/client/main.go
+++ b/3.0/adaptivesvc-triple/client/main.go
@@ -68,15 +68,7 @@ func main() {
 		switch funcName {
 		case Fibonacci:
 			if result, err := fibonacci(ctx, provider); err != nil {
-				if clusterutils.DoesAdaptiveServiceReachLimitation(err) {
-					logger.Infof("Reach Limitation")
-				} else if err.Error() == context.DeadlineExceeded.Error() {
-					logger.Warnf("Consumer Request Timeout, err: %v", err)
-				} else if offline_simulator.IsServerOfflineErr(err) {
-					logger.Warnf("Server offline, err: %v", err)
-				} else {
-					panic(err)
-				}
+				handleErr(err)
 			} else {
 				fmt.Printf("%s result: %d\n", Fibonacci, result.Result)
 			}
@@ -126,4 +118,16 @@ func sleep(ctx context.Context, provider *api.ProviderClientImpl) {
 		Time: int64(duration),
 	}
 	_, _ = provider.Sleep(ctx, req)
+}
+
+func handleErr(err error) {
+	if clusterutils.DoesAdaptiveServiceReachLimitation(err) {
+		logger.Infof("Reach Limitation")
+	} else if err.Error() == context.DeadlineExceeded.Error() {
+		logger.Warnf("Consumer Request Timeout, err: %v", err)
+	} else if offline_simulator.IsServerOfflineErr(err) {
+		logger.Warnf("Server offline, err: %v", err)
+	} else {
+		panic(err)
+	}
 }

--- a/3.0/adaptivesvc-triple/server/dubbogo-local.yml
+++ b/3.0/adaptivesvc-triple/server/dubbogo-local.yml
@@ -20,6 +20,7 @@ dubbo:
     adaptive-service-verbose: true
     services:
       Provider:
+        filter: offlineSimulator
         protocol: my-protocol
         interface: org.apache.dubbo.Provider
   # If you want to debug adaptive service, please uncomment the following codes.

--- a/3.0/adaptivesvc-triple/server/main.go
+++ b/3.0/adaptivesvc-triple/server/main.go
@@ -33,6 +33,7 @@ import (
 
 import (
 	"github.com/dubbogo/dubbo-go-benchmark/3.0/adaptivesvc-triple/api"
+	_ "github.com/dubbogo/dubbo-go-benchmark/3.0/filters/offline_simulator"
 )
 
 const (

--- a/3.0/adaptivesvc-triple/server/main.go
+++ b/3.0/adaptivesvc-triple/server/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	if timeoutDurationStr := os.Getenv(TimeoutDuration); timeoutDurationStr == "" && timeoutRatio > 0 {
 		panic(fmt.Errorf("%s is required", TimeoutDuration))
-	} else {
+	} else if timeoutDurationStr != "" {
 		timeoutDuration, err = time.ParseDuration(timeoutDurationStr)
 		if err != nil {
 			panic(fmt.Errorf("%s should be a string representing a time, like \"1h\", \"30m\", etc", TimeoutDuration))

--- a/3.0/adaptivesvc-triple/server/main.go
+++ b/3.0/adaptivesvc-triple/server/main.go
@@ -42,6 +42,7 @@ const (
 	TimeoutDuration = "TIMEOUT_DURATION"
 	//TimeoutRatio should be a decimal between 0 and 1.
 	TimeoutRatio = "TIMEOUT_RATIO"
+	RandSeed     = "RAND_SEED"
 )
 
 var (
@@ -53,7 +54,19 @@ var ErrNShouldGreaterThanZero = fmt.Errorf("n should greater than zero")
 
 func main() {
 
-	var err error
+	var (
+		err      error
+		randSeed int64
+	)
+	if randSeedStr := os.Getenv(RandSeed); randSeedStr != "" {
+		randSeed, err = strconv.ParseInt(randSeedStr, 10, 64)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a integer", RandSeed))
+		}
+	} else {
+		randSeed = time.Now().Unix()
+	}
+	rand.Seed(randSeed)
 
 	if timeoutRateStr := os.Getenv(TimeoutRatio); timeoutRateStr != "" {
 		timeoutRatio, err = strconv.ParseFloat(timeoutRateStr, 64)

--- a/3.0/adaptivesvc/client/main.go
+++ b/3.0/adaptivesvc/client/main.go
@@ -12,8 +12,11 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/logger"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	_ "dubbo.apache.org/dubbo-go/v3/imports"
-
 	testerpkg "github.com/dubbogo/tools/pkg/tester"
+)
+
+import (
+	"github.com/dubbogo/dubbo-go-benchmark/3.0/filters/offline_simulator"
 )
 
 const (
@@ -75,6 +78,8 @@ func main() {
 					logger.Infof("Reach Limitation")
 				} else if err.Error() == ErrConsumerRequestTimeoutStr {
 					logger.Warnf("Consumer Request Timeout, err: %v", err)
+				} else if offline_simulator.IsServerOffline(err) {
+					logger.Warnf("Server offline, err: %v", err)
 				} else {
 					panic(err)
 				}

--- a/3.0/adaptivesvc/client/main.go
+++ b/3.0/adaptivesvc/client/main.go
@@ -74,15 +74,7 @@ func main() {
 		switch funcName {
 		case Fibonacci:
 			if result, err := fibonacci(ctx, provider); err != nil {
-				if clusterutils.DoesAdaptiveServiceReachLimitation(err) {
-					logger.Infof("Reach Limitation")
-				} else if err.Error() == ErrConsumerRequestTimeoutStr {
-					logger.Warnf("Consumer Request Timeout, err: %v", err)
-				} else if offline_simulator.IsServerOfflineErr(err) {
-					logger.Warnf("Server offline, err: %v", err)
-				} else {
-					panic(err)
-				}
+				handleErr(err)
 			} else {
 				fmt.Printf("%s result: %d\n", Fibonacci, result)
 			}
@@ -125,4 +117,16 @@ func sleep(ctx context.Context, provider *Provider) {
 		panic(err)
 	}
 	_, _ = provider.Sleep(ctx, int64(duration))
+}
+
+func handleErr(err error) {
+	if clusterutils.DoesAdaptiveServiceReachLimitation(err) {
+		logger.Infof("Reach Limitation")
+	} else if err.Error() == ErrConsumerRequestTimeoutStr {
+		logger.Warnf("Consumer Request Timeout, err: %v", err)
+	} else if offline_simulator.IsServerOfflineErr(err) {
+		logger.Warnf("Server offline, err: %v", err)
+	} else {
+		panic(err)
+	}
 }

--- a/3.0/adaptivesvc/client/main.go
+++ b/3.0/adaptivesvc/client/main.go
@@ -78,7 +78,7 @@ func main() {
 					logger.Infof("Reach Limitation")
 				} else if err.Error() == ErrConsumerRequestTimeoutStr {
 					logger.Warnf("Consumer Request Timeout, err: %v", err)
-				} else if offline_simulator.IsServerOffline(err) {
+				} else if offline_simulator.IsServerOfflineErr(err) {
 					logger.Warnf("Server offline, err: %v", err)
 				} else {
 					panic(err)

--- a/3.0/adaptivesvc/server/dubbogo-local.yml
+++ b/3.0/adaptivesvc/server/dubbogo-local.yml
@@ -20,6 +20,7 @@ dubbo:
     adaptive-service-verbose: true
     services:
       Provider:
+        filter: offlineSimulator
         protocol: my-protocol
         interface: org.apache.dubbo.Provider
   # If you want to debug adaptive service, please uncomment the following codes.

--- a/3.0/adaptivesvc/server/main.go
+++ b/3.0/adaptivesvc/server/main.go
@@ -41,6 +41,7 @@ const (
 	TimeoutDuration = "TIMEOUT_DURATION"
 	//TimeoutRatio should be a decimal between 0 and 1.
 	TimeoutRatio = "TIMEOUT_RATIO"
+	RandSeed     = "RAND_SEED"
 )
 
 var (
@@ -108,7 +109,19 @@ func (*Provider) Sleep(duration int64) (int64, error) {
 
 func main() {
 
-	var err error
+	var (
+		err      error
+		randSeed int64
+	)
+	if randSeedStr := os.Getenv(RandSeed); randSeedStr != "" {
+		randSeed, err = strconv.ParseInt(randSeedStr, 10, 64)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a integer", RandSeed))
+		}
+	} else {
+		randSeed = time.Now().Unix()
+	}
+	rand.Seed(randSeed)
 
 	if timeoutRateStr := os.Getenv(TimeoutRatio); timeoutRateStr != "" {
 		timeoutRatio, err = strconv.ParseFloat(timeoutRateStr, 64)

--- a/3.0/adaptivesvc/server/main.go
+++ b/3.0/adaptivesvc/server/main.go
@@ -135,7 +135,7 @@ func main() {
 
 	if timeoutDurationStr := os.Getenv(TimeoutDuration); timeoutDurationStr == "" && timeoutRatio > 0 {
 		panic(fmt.Errorf("%s is required", TimeoutDuration))
-	} else {
+	} else if timeoutDurationStr != "" {
 		timeoutDuration, err = time.ParseDuration(timeoutDurationStr)
 		if err != nil {
 			panic(fmt.Errorf("%s should be a string representing a time, like \"1h\", \"30m\", etc", TimeoutDuration))

--- a/3.0/adaptivesvc/server/main.go
+++ b/3.0/adaptivesvc/server/main.go
@@ -31,6 +31,10 @@ import (
 	_ "dubbo.apache.org/dubbo-go/v3/imports"
 )
 
+import (
+	_ "github.com/dubbogo/dubbo-go-benchmark/3.0/filters/offline_simulator"
+)
+
 const (
 	// TimeoutDuration should be a string representing a time,
 	// like "1h", "30m", etc.

--- a/3.0/filters/offline_simulator/offline_simulator.go
+++ b/3.0/filters/offline_simulator/offline_simulator.go
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package offline_simulator
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
+	"dubbo.apache.org/dubbo-go/v3/filter"
+	"dubbo.apache.org/dubbo-go/v3/protocol"
+)
+
+type ServerState string
+
+const (
+	ServerStateOnline  ServerState = "Online"
+	ServerStateOffline ServerState = "Offline"
+
+	// MinOnlineDuration should be a string representing a time,
+	// like "1h", "30m", etc.
+	MinOnlineDuration  = "MIN_ONLINE_DURATION"
+	MaxOnlineDuration  = "MAX_ONLINE_DURATION"
+	MinOfflineDuration = "MIN_OFFLINE_DURATION"
+	MaxOfflineDuration = "MAX_OFFLINE_DURATION"
+	//OfflineRatio should be a decimal between 0 and 1.
+	OfflineRatio = "OFFLINE_RATIO"
+)
+
+var ErrServerOffline = fmt.Errorf("server is offline")
+
+type OfflineSimulator struct {
+	State              ServerState
+	OfflineRatio       float64
+	MinOnlineDuration  time.Duration
+	MaxOnlineDuration  *time.Duration //optional
+	MinOfflineDuration time.Duration
+	MaxOfflineDuration *time.Duration //optional
+	LastTransferTime   time.Time
+}
+
+func init() {
+	extension.SetFilter("offlineSimulator", NewOfflineSimulator)
+}
+
+func NewOfflineSimulator() filter.Filter {
+	var (
+		err                error
+		offlineRatio       float64
+		minOnlineDuration  time.Duration
+		maxOnlineDuration  *time.Duration
+		minOfflineDuration time.Duration
+		maxOfflineDuration *time.Duration
+	)
+
+	if offlineRatioStr := os.Getenv(OfflineRatio); offlineRatioStr != "" {
+		offlineRatio, err = strconv.ParseFloat(offlineRatioStr, 64)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a decimal", OfflineRatio))
+		}
+		if offlineRatio > 1 || offlineRatio < 0 {
+			panic(fmt.Errorf("%s should be a decimal between 0 and 1 ", OfflineRatio))
+		}
+	}
+
+	if minOnlineDurationStr := os.Getenv(MinOnlineDuration); minOnlineDurationStr == "" && offlineRatio > 0 {
+		panic(fmt.Errorf("%s is required", MinOnlineDuration))
+	} else {
+		minOnlineDuration, err = time.ParseDuration(minOnlineDurationStr)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a string representing a time, like \"1h\", \"30m\", etc", MinOnlineDuration))
+		}
+	}
+
+	if minOfflineDurationStr := os.Getenv(MinOfflineDuration); minOfflineDurationStr == "" && offlineRatio > 0 {
+		panic(fmt.Errorf("%s is required", MinOfflineDuration))
+	} else {
+		minOfflineDuration, err = time.ParseDuration(minOfflineDurationStr)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a string representing a time, like \"1h\", \"30m\", etc", MinOfflineDuration))
+		}
+	}
+
+	if maxOfflineDurationStr := os.Getenv(MaxOfflineDuration); maxOfflineDurationStr != "" {
+		duration, err := time.ParseDuration(maxOfflineDurationStr)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a string representing a time, like \"1h\", \"30m\", etc", MaxOfflineDuration))
+		}
+		maxOfflineDuration = &duration
+	}
+
+	if maxOnlineDurationStr := os.Getenv(MaxOnlineDuration); maxOnlineDurationStr != "" {
+		duration, err := time.ParseDuration(maxOnlineDurationStr)
+		if err != nil {
+			panic(fmt.Errorf("%s should be a string representing a time, like \"1h\", \"30m\", etc", MaxOnlineDuration))
+		}
+		maxOnlineDuration = &duration
+	}
+
+	s := &OfflineSimulator{
+		State:              ServerStateOnline,
+		OfflineRatio:       offlineRatio,
+		MinOnlineDuration:  minOnlineDuration,
+		MaxOnlineDuration:  maxOnlineDuration,
+		MinOfflineDuration: minOfflineDuration,
+		MaxOfflineDuration: maxOfflineDuration,
+		LastTransferTime:   time.Now(),
+	}
+	go s.Run()
+	return s
+}
+
+//Run an offline simulator
+//1. if the duration of the current state is less than the minimum limit, sleep until greater than it;
+//2. if the duration is greater than the maximum limit (if set), switch the state immediately;
+//3. otherwise, switch the state with a certain probability every second.
+func (f *OfflineSimulator) Run() {
+	for {
+		now := time.Now()
+		switch f.State {
+		case ServerStateOnline:
+			if duration := now.Sub(f.LastTransferTime); duration < f.MinOnlineDuration {
+				time.Sleep(f.MinOnlineDuration - duration + time.Second)
+			} else if f.MaxOnlineDuration != nil && duration > *f.MaxOnlineDuration || rand.Float64() < f.OfflineRatio {
+				f.State = ServerStateOffline
+				f.LastTransferTime = time.Now()
+			} else {
+				time.Sleep(time.Second)
+			}
+		case ServerStateOffline:
+			if duration := now.Sub(f.LastTransferTime); duration < f.MinOfflineDuration {
+				time.Sleep(f.MinOfflineDuration - duration + time.Second)
+			} else if f.MaxOfflineDuration != nil && duration > *f.MaxOfflineDuration || rand.Float64() > f.OfflineRatio {
+				f.State = ServerStateOnline
+				f.LastTransferTime = time.Now()
+			} else {
+				time.Sleep(time.Second)
+			}
+		}
+	}
+}
+
+func IsServerOffline(err error) bool {
+	if err == nil {
+		return false
+	}
+	return err.Error() == ErrServerOffline.Error()
+}
+
+func (f *OfflineSimulator) Invoke(ctx context.Context, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
+	if f.State == ServerStateOffline {
+		return &protocol.RPCResult{
+			Attrs: nil,
+			Err:   ErrServerOffline,
+			Rest:  nil,
+		}
+	}
+	return invoker.Invoke(ctx, invocation)
+}
+
+func (f *OfflineSimulator) OnResponse(ctx context.Context, result protocol.Result, invoker protocol.Invoker, protocol protocol.Invocation) protocol.Result {
+	return result
+}

--- a/3.0/filters/offline_simulator/offline_simulator.go
+++ b/3.0/filters/offline_simulator/offline_simulator.go
@@ -178,7 +178,7 @@ func (f *OfflineSimulator) Invoke(ctx context.Context, invoker protocol.Invoker,
 	return invoker.Invoke(ctx, invocation)
 }
 
-func (f *OfflineSimulator) OnResponse(ctx context.Context, result protocol.Result, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
+func (f *OfflineSimulator) OnResponse(_ context.Context, result protocol.Result, _ protocol.Invoker, _ protocol.Invocation) protocol.Result {
 	if f.State == ServerStateOffline {
 		return &protocol.RPCResult{
 			Attrs: nil,

--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ First, you should have 3 cloud server, under same local network. Build `stress` 
 
 Pay attention that sometime the parallel is too small to meet your expect tps, for example, with 4c8g machine, you set parallel to 1 and set tps to 5000, the result tps is not as you expected, and you should increase parallel to 10 or other larger number.
 
+## 4. Environments in AdaptiveService Benchmark
+1. Random Timeout
+   - export RAND_SEED=3             # random seed
+   - export TIMEOUT_RATIO=0.05      # your expected timeout ratio
+   - export TIMEOUT_DURATION=5s     # your expected timeout duration
+2. Random Offline
+   - export RAND_SEED=3             # random seed
+   - export OFFLINE_RATIO=0.05      # your expected server offline ratio
+   - export MIN_ONLINE_DURATION=5s  # your expected minimum online duration
+   - export MAX_ONLINE_DURATION=10s # your expected maximum online duration (optional)
+   - export MIN_OFFLINE_DURATION=3s # your expected minimum offline duration
+   - export MAX_OFFLINE_DURATION=8s # your expected maximum offline duration (optional)


### PR DESCRIPTION
Following env is used in this feature: 
- RAND_SEED
- OFFLINE_RATIO
- MIN_ONLINE_DURATION
- MAX_ONLINE_DURATION
- MIN_OFFLINE_DURATION
- MAX_OFFLINE_DURATION

Using this feature should import "github.com/dubbogo/dubbo-go-benchmark/3.0/filters/offline_simulator" and add the offlineSimulator filter on server side 

When the OFFLINE_RATIO > 0, the simulator will run according to the following logic:
1. if the duration of the current state is less than the minimum limit, sleep until greater than it;
2. if the duration is greater than the maximum limit (if set), switch the state immediately;
3. otherwise, switch the state with a certain probability every second.